### PR TITLE
fixed typo: unescaped backslash in Telink_Tools.py

### DIFF
--- a/Telink_Tools.py
+++ b/Telink_Tools.py
@@ -359,7 +359,7 @@ def main(custom_commandline=None):
         print("                                  ")
         print("              / ------470------SWS")
         print("Tx ----------+                    ")
-        print("              \ ------470------Rx ")
+        print("              \\ ------470------Rx ")
         print("Rx ----------------------------Tx ")
         print("RTS----------------------------RST")
 


### PR DESCRIPTION
I just fixed the typo, because I saw the message "Please check the connection!" and found it slightly irritating.
Telink_Tools.py:362: SyntaxWarning: invalid escape sequence '\ '